### PR TITLE
Add @bake_task as an alternative to bake_task for declaring a function as a task

### DIFF
--- a/bake
+++ b/bake
@@ -134,6 +134,17 @@ function bake_require_all () {
 }
 
 # bake_task taskname ["description"]
+function @bake_task () {
+  local fnline name
+  fnline=$((${BASH_LINENO[0]}+1))
+  name="$(sed "${fnline}q;d" "${BASH_SOURCE[1]}" | sed -e 's/^function //' -e 's/()//' -e 's/{//' | awk '{$1=$1};1')"
+
+  local short_desc="${1:-No Description for task: $name}"
+  BAKE_TASKS[$name]="$name"
+  BAKE_TASK_DESCRIPTIONS[$name]="$short_desc"
+}
+
+# bake_task taskname ["description"]
 function bake_task () {
   local name="${1:-}"
   local short_desc="${2:-No Description for task: $name}"
@@ -916,80 +927,46 @@ function bake_echo_dgray    () {
   bake_color_echo "$BAKE_COLOR_DGRAY" "$*"
 }
 
+function bake_log_internal () {
+  local levelname level threshold color
+  levelname="$1"
+  level="$2"
+  color="$3"
+  shift 3
 
-function bake_log_debug () {
-  if [[ "$BAKE_LOG_LEVEL" -ge "$BAKE_LOG_LEVEL_DEBUG" ]]; then
+  if [[ "$BAKE_LOG_LEVEL" -ge "$level" ]]; then
     local source_line=
     if [[ "$BAKE_OPT_LOG_LINES" == 1 ]]; then
       source_line=" (${BASH_SOURCE[1]}:${BASH_LINENO[0]})"
     fi
-    local statement="[DEBUG ${FUNCNAME[1]}$source_line] $*"
-    if [[ -n "$BAKE_OPT_LOG_DEBUG_COLOR" ]]; then
-      bake_color_echo "$BAKE_OPT_LOG_DEBUG_COLOR" "$statement" > "$BAKE_LOG_DEST"
+    local statement="[$levelname ${FUNCNAME[1]}$source_line] $*"
+    if [[ -n "$color" ]]; then
+      bake_color_echo "$color" "$statement" > "$BAKE_LOG_DEST"
     else
       echo "$statement" > "$BAKE_LOG_DEST"
     fi
   fi
+}
+
+
+function bake_log_debug () {
+  bake_log_internal DEBUG "$BAKE_LOG_LEVEL_DEBUG" "$BAKE_OPT_LOG_DEBUG_COLOR" "$*"
 }
 
 function bake_log_info () {
-  if [[ "$BAKE_LOG_LEVEL" -ge "$BAKE_LOG_LEVEL_INFO" ]]; then
-    local source_line=
-    if [[ "$BAKE_OPT_LOG_LINES" == 1 ]]; then
-      source_line=" (${BASH_SOURCE[1]}:${BASH_LINENO[0]})"
-    fi
-    local statement="[INFO  ${FUNCNAME[1]}$source_line] $*"
-    if [[ -n "$BAKE_OPT_LOG_INFO_COLOR" ]]; then
-      bake_color_echo "$BAKE_OPT_LOG_INFO_COLOR" "$statement" > "$BAKE_LOG_DEST"
-    else
-      echo "$statement" > "$BAKE_LOG_DEST"
-    fi
-  fi
+  bake_log_internal INFO "$BAKE_LOG_LEVEL_INFO" "$BAKE_OPT_LOG_INFO_COLOR" "$*"
 }
 
 function bake_log_warn () {
-  if [[ "$BAKE_LOG_LEVEL" -ge "$BAKE_LOG_LEVEL_WARN" ]]; then
-    local source_line=
-    if [[ "$BAKE_OPT_LOG_LINES" == 1 ]]; then
-      source_line=" (${BASH_SOURCE[1]}:${BASH_LINENO[0]})"
-    fi
-    local statement="[WARN  ${FUNCNAME[1]}$source_line] $*"
-    if [[ -n "$BAKE_OPT_LOG_WARN_COLOR" ]]; then
-      bake_color_echo "$BAKE_OPT_LOG_WARN_COLOR" "$statement" > "$BAKE_LOG_DEST"
-    else
-      echo "$statement" > "$BAKE_LOG_DEST"
-    fi
-  fi
+  bake_log_internal WARN "$BAKE_LOG_LEVEL_WARN" "$BAKE_OPT_LOG_WARN_COLOR" "$*"
 }
 
 function bake_log_error () {
-  if [[ "$BAKE_LOG_LEVEL" -ge "$BAKE_LOG_LEVEL_ERROR" ]]; then
-    local source_line=
-    if [[ "$BAKE_OPT_LOG_LINES" == 1 ]]; then
-      source_line=" (${BASH_SOURCE[1]}:${BASH_LINENO[0]})"
-    fi
-    local statement="[ERROR ${FUNCNAME[1]}$source_line] $*"
-    if [[ -n "$BAKE_OPT_LOG_ERROR_COLOR" ]]; then
-      bake_color_echo "$BAKE_OPT_LOG_ERROR_COLOR" "$statement" > "$BAKE_LOG_DEST"
-    else
-      echo "$statement" > "$BAKE_LOG_DEST"
-    fi
-  fi
+  bake_log_internal ERROR "$BAKE_LOG_LEVEL_ERROR" "$BAKE_OPT_LOG_ERROR_COLOR" "$*"
 }
 
 function bake_log_fatal () {
-  if [[ "$BAKE_LOG_LEVEL" -ge "$BAKE_LOG_LEVEL_FATAL" ]]; then
-    local source_line=
-    if [[ "$BAKE_OPT_LOG_LINES" == 1 ]]; then
-      source_line=" (${BASH_SOURCE[1]}:${BASH_LINENO[0]})"
-    fi
-    local statement="[FATAL ${FUNCNAME[1]}$source_line] $*"
-    if [[ -n "$BAKE_OPT_LOG_FATAL_COLOR" ]]; then
-      bake_color_echo "$BAKE_OPT_LOG_FATAL_COLOR" "$statement" > "$BAKE_LOG_DEST"
-    else
-      echo "$statement" > "$BAKE_LOG_DEST"
-    fi
-  fi
+  bake_log_internal FATAL "$BAKE_LOG_LEVEL_FATAL" "$BAKE_OPT_LOG_FATAL_COLOR" "$*"
 }
 
 function bake_log_level () {

--- a/bake
+++ b/bake
@@ -133,10 +133,14 @@ function bake_require_all () {
   done
 }
 
-# bake_task taskname ["description"]
+# @bake_task [description]
+# Note: This function should be called on the line directly before the function definition
+#       that you wish to make into a bake task
 function @bake_task () {
   local fnline name
   fnline=$((${BASH_LINENO[0]}+1))
+  # TODO ischaaf: add protections against using this improperly as right now it will
+  # generate weird bake task names
   name="$(sed "${fnline}q;d" "${BASH_SOURCE[1]}" | sed -e 's/^function //' -e 's/()//' -e 's/{//' | awk '{$1=$1};1')"
 
   local short_desc="${1:-No Description for task: $name}"

--- a/examples/simple/Bakefile
+++ b/examples/simple/Bakefile
@@ -3,24 +3,36 @@ set -eu -o pipefail
 
 bake_require bakescripts.sh
 
-bake_task task.1 "simple task"
+bake_log_level debug
+
+BAKE_OPT_LOG_DEBUG_COLOR="$BAKE_COLOR_DGRAY"
+BAKE_OPT_LOG_INFO_COLOR="$BAKE_COLOR_NORMAL"
+BAKE_OPT_LOG_WARN_COLOR="$BAKE_COLOR_YELLOW"
+BAKE_OPT_LOG_ERROR_COLOR="$BAKE_COLOR_LRED"
+BAKE_OPT_LOG_FATAL_COLOR="$BAKE_COLOR_RED"
+
+@bake_task "simple task"
 function task.1 () {
-  echo "you ran a task!"
+  bake_log_debug "you ran a task!"
+  bake_log_info "you ran a task!"
+  bake_log_warn "you ran a task!"
+  bake_log_error "you ran a task!"
+  bake_log_fatal "you ran a task!"
 }
 
-bake_task task.2 "pass me some args"
-function task.2 () {
+@bake_task "pass me some args"
+function task.2 {
   echo "You passed: $*"
 }
 
-bake_task remove.bakefile "move the bakefile to test when no file exists"
-function remove.bakefile () {
+@bake_task "move the bakefile to test when no file exists"
+remove.bakefile () {
   echo "To restore Bakefile run:"
   echo "mv Bakefile{.bak,}"
   mv Bakefile{,.bak}
 }
 
-bake_task my.func!
+@bake_task my.func!
 function my.func! () {
   bake_echo_green "foo"
 }

--- a/examples/simple/bakescripts.sh
+++ b/examples/simple/bakescripts.sh
@@ -2,7 +2,7 @@
 set -eu -o pipefail
 
 
-bake_task external.func "External Function"
+@bake_task "External Function"
 function external.func () {
   echo "This came from another file!"
 }


### PR DESCRIPTION
Currently `bake_task <fn> [description]` is great, but it can sometimes be cumbersome to add tasks as the function name must be typed out twice (once in the actual definition of the function, and once in the call to `bake_task`).
This PR adds a new "decorator-like" function that relies on parsing the source file to find the function name.
```bash
# example usage
@bake_task
function my_task () {
  # do stuff
}
```
This will create a bake_task for the `my_task` function.
Note that this new function relies on being placed directly before the function you want to turn into a task.